### PR TITLE
fix some issue that some var use without lock

### DIFF
--- a/pbft-core/node.go
+++ b/pbft-core/node.go
@@ -273,9 +273,10 @@ func (req *Request) addSig(privKey *ecdsa.PrivateKey) {
 	e := gob.NewEncoder(&b)
 	err := e.Encode(req.Inner)
 	if err != nil {
-		MyPrint(3, "%s", `failed to encode!\n`)
-		fmt.Println(err)
+		MyPrint(3, "%s err:%s", `failed to encode!\n`, err.Error())
+		return
 	}
+
 	s := getHash(string(b.Bytes()))
 	MyPrint(1, "digest %s.\n", string(s))
 	req.Dig = DigType(s)
@@ -295,8 +296,10 @@ func (req *Request) verifyDig() bool {
 	e := gob.NewEncoder(&b)
 	err := e.Encode(req.Inner)
 	if err != nil {
-		MyPrint(3, "%s", `failed to encode!`)
+		MyPrint(3, "%s err:%s", `failed to encode!`, err.Error())
+		return false
 	}
+
 	s := getHash(string(b.Bytes()))
 	return s == string(req.Dig)
 }
@@ -520,13 +523,17 @@ func (nd *Node) executeInOrder(req Request) {
 		if ok {
 			seq += 1
 			r = rtemp
+			nd.mu.Lock()
 			delete(nd.waiting, seq)
+			nd.mu.Unlock()
 		}
 
 	}
 
 	if waiting {
+		nd.mu.Lock()
 		nd.waiting[req.Inner.Seq] = req
+		nd.mu.Unlock()
 	}
 }
 
@@ -538,7 +545,7 @@ func (nd *Node) serverLoop() {
 
 	l, e := net.Listen("tcp", ":"+strconv.Itoa(nd.port))
 	if e != nil {
-		MyPrint(3, "listen error:", e)
+		MyPrint(3, "listen error:%s", e.Error())
 	}
 
 	go server.Accept(l)
@@ -557,12 +564,8 @@ func (nd *Node) processCheckpoint(req Request, clientID int) {
 }
 
 func (nd *Node) isInClientLog(req Request) bool {
-	req, ok := nd.clientMessageLog[clientMessageLogItem{req.Inner.Id, req.Inner.Timestamp}]
-	if !ok {
-		return false
-	} else {
-		return true
-	}
+	_, ok := nd.clientMessageLog[clientMessageLogItem{req.Inner.Id, req.Inner.Timestamp}]
+	return ok
 }
 
 func (nd *Node) addClientLog(req Request) {
@@ -691,6 +694,8 @@ func (nd *Node) initializeKeys() {
 }
 
 func (nd *Node) incPrepDict(dig DigType) {
+	nd.mu.Lock()
+	defer nd.mu.Unlock()
 	if val, ok := nd.prepDict[dig]; ok {
 		val.number += 1
 		nd.prepDict[dig] = val
@@ -701,6 +706,8 @@ func (nd *Node) incPrepDict(dig DigType) {
 }
 
 func (nd *Node) incCommDict(dig DigType) {
+	nd.mu.Lock()
+	defer nd.mu.Unlock()
 	if val, ok := nd.commDict[dig]; ok {
 		val.number += 1
 		nd.commDict[dig] = val
@@ -785,9 +792,7 @@ func (nd *Node) processPrePrepare(req Request, clientId int) {
 	m := nd.createRequest(TYPE_PREP, req.Inner.Seq, MsgType(req.Inner.Msg)) // TODO: check content!
 	nd.nodeMessageLog.set(m.Inner.Reqtype, m.Inner.Seq, m.Inner.Id, m)
 	nd.recordPBFT(m)
-	nd.mu.Lock()
 	nd.incPrepDict(DigType(req.Inner.Msg))
-	nd.mu.Unlock()
 	nd.broadcast(m)
 	if nd.checkPrepareMargin(DigType(req.Inner.Msg), req.Inner.Seq) { // TODO: check dig vs Inner.Msg
 		nd.record("PREPARED sequence number " + strconv.Itoa(req.Inner.Seq) + "\n")
@@ -835,18 +840,14 @@ func (nd *Node) addNodeHistory(req Request) {
 
 func (nd *Node) processPrepare(req Request, clientId int) {
 	nd.addNodeHistory(req)
-	nd.mu.Lock()
 	nd.incPrepDict(DigType(req.Inner.Msg))
-	nd.mu.Unlock()
 	if nd.checkPrepareMargin(DigType(req.Inner.Msg), req.Inner.Seq) { // TODO: check dig vs Inner.Msg
 		MyPrint(2, "[%d] Checked Margin\n", nd.id)
 		nd.record("PREPARED sequence number " + strconv.Itoa(req.Inner.Seq) + "\n")
 		m := nd.createRequest(TYPE_COMM, req.Inner.Seq, req.Inner.Msg) // TODO: check content
 		nd.broadcast(m)
 		nd.nodeMessageLog.set(m.Inner.Reqtype, m.Inner.Seq, m.Inner.Id, m)
-		nd.mu.Lock()
 		nd.incCommDict(m.Dig) //TODO: check content
-		nd.mu.Unlock()
 		nd.recordPBFT(m)
 		nd.prepared[req.Inner.Seq] = m // or msg?
 		if nd.checkCommittedMargin(m.Dig, m) {
@@ -859,9 +860,7 @@ func (nd *Node) processPrepare(req Request, clientId int) {
 
 func (nd *Node) processCommit(req Request) {
 	nd.addNodeHistory(req)
-	nd.mu.Lock()
 	nd.incCommDict(DigType(req.Inner.Msg))
-	nd.mu.Unlock()
 	if nd.checkCommittedMargin(DigType(req.Inner.Msg), req) {
 		MyPrint(2, "[%d] Committed %v\n", nd.id, req)
 		nd.record("COMMITTED seq number " + strconv.Itoa(req.Inner.Seq))


### PR DESCRIPTION
解决了以下的问题：

1. 一些变量读写并没有加锁保护
2. 一些地方出现error，应该return而没有return
3. 建议用同一的方法打日志，而不是fmt.Printf和自定义方法MyPrint混用（可能还存在其他地方）


一些建议：
1. node那个struct由于有好几个属性变量，但是node只有一个lock，是否可以按照成员属性变量对于有一个锁，进而提高效率？
2. 建议对属性变量的修改，涉及到锁保护的，都封装为函数，尽可能很简短的函数。函数里面统一加上mu.lock()和defer mu.Unlock(),否则非常容易出现死锁，尤其在node.go那个文件，里面有些函数比较长的情况。 