### PR TITLE
update path for hmake

### DIFF
--- a/pbft/README.md
+++ b/pbft/README.md
@@ -35,7 +35,7 @@ export PATH=$PATH:$GOBIN
 Then,
 
 ```
-cd $GOPATH/src/github.com/truechain/truechain-consensus-core
+cd $GOPATH/src/github.com/truechain/truechain-consensus-core/pbft
 hmake
 cp bin/{linux/darwin}/truechain-engine $GOBIN/
 ```


### PR DESCRIPTION
The path given in README (`cd $GOPATH/src/github.com/truechain/truechain-consensus-core`) is incorrect it should be `cd $GOPATH/src/github.com/truechain/truechain-consensus-core/pbft`
@arcolife 