### PR TITLE
Verify transaction requests from client on pbft end

### DIFF
--- a/pbft/src/pbft-core/client/client.go
+++ b/pbft/src/pbft-core/client/client.go
@@ -27,6 +27,7 @@ import (
 	"pbft-core"
 	"pbft-core/pbft-server"
 
+	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -72,7 +73,9 @@ func (cl *Client) LoadPbftClientConfig() {
 
 func (cl *Client) addSig(txnData *pb.TxnData) {
 	if cl.privKey != nil {
-		hashData := ethcrypto.Keccak256(txnData.Payload)
+		data, _ := proto.Marshal(txnData)
+		hashData := ethcrypto.Keccak256(data)
+		txnData.Hash = hashData
 		sig, _ := ethcrypto.Sign(hashData, cl.privKey)
 		txnData.Signature = sig
 	}
@@ -90,8 +93,6 @@ func (cl *Client) NewRequest(msg string, timeStamp int64) {
 				Recipient:    []byte(""),
 				Amount:       0,
 				Payload:      []byte(msg),
-				Hash:         []byte(""),
-				Signature:    []byte(""),
 			},
 		}
 

--- a/pbft/src/pbft-core/config.go
+++ b/pbft/src/pbft-core/config.go
@@ -49,10 +49,9 @@ type Config struct {
 
 // GenerateKeysToFile generates ECDSA public-private keypairs to a folder
 func (cfg *Config) GenerateKeysToFile(numKeys int) {
-	// IdCount := 1000
-	cfg.KD = path.Join(GetCWD(), "keys/")
 	MakeDirIfNot(cfg.KD)
 	WriteNewKeys(numKeys, cfg.KD)
+
 	MyPrint(1, "Generated %d keypairs in %s folder..\n", numKeys, cfg.KD)
 }
 
@@ -63,6 +62,6 @@ func (cfg *Config) LoadPbftSimConfig() {
 	cfg.NumKeys = len(cfg.IPList)
 	cfg.N = cfg.NumKeys - 1 // we assume client count to be 1
 	cfg.NumQuest = 100
-	cfg.GenerateKeysToFile(cfg.NumKeys)
 	cfg.Blocksize = 10 // This is hardcoded to 10 for now
+	cfg.KD = path.Join(GetCWD(), "keys/")
 }

--- a/pbft/src/pbft-core/config.go
+++ b/pbft/src/pbft-core/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	HostsFile string   // network config file, to read IP addresses from
 	NumQuest  int      // NumQuest is the number of requests sent from client
 	NumKeys   int      // NumKeys is the count of IP addresses (BFT nodes) participating
+	Blocksize int      // Blocksize specifies the number of transactions per block
 }
 
 // GenerateKeysToFile generates ECDSA public-private keypairs to a folder
@@ -63,4 +64,5 @@ func (cfg *Config) LoadPbftSimConfig() {
 	cfg.N = cfg.NumKeys - 1 // we assume client count to be 1
 	cfg.NumQuest = 100
 	cfg.GenerateKeysToFile(cfg.NumKeys)
+	cfg.Blocksize = 10 // This is hardcoded to 10 for now
 }

--- a/pbft/src/pbft-core/fastchain/fastchain.pb.go
+++ b/pbft/src/pbft-core/fastchain/fastchain.pb.go
@@ -36,7 +36,7 @@ func (m *Request) Reset()         { *m = Request{} }
 func (m *Request) String() string { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{0}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{0}
 }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
@@ -93,7 +93,7 @@ func (m *Request_Inner) Reset()         { *m = Request_Inner{} }
 func (m *Request_Inner) String() string { return proto.CompactTextString(m) }
 func (*Request_Inner) ProtoMessage()    {}
 func (*Request_Inner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{0, 0}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{0, 0}
 }
 func (m *Request_Inner) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request_Inner.Unmarshal(m, b)
@@ -168,7 +168,7 @@ func (m *PbftNode) Reset()         { *m = PbftNode{} }
 func (m *PbftNode) String() string { return proto.CompactTextString(m) }
 func (*PbftNode) ProtoMessage()    {}
 func (*PbftNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{1}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{1}
 }
 func (m *PbftNode) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PbftNode.Unmarshal(m, b)
@@ -220,7 +220,7 @@ func (m *Nodes) Reset()         { *m = Nodes{} }
 func (m *Nodes) String() string { return proto.CompactTextString(m) }
 func (*Nodes) ProtoMessage()    {}
 func (*Nodes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{2}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{2}
 }
 func (m *Nodes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Nodes.Unmarshal(m, b)
@@ -265,7 +265,7 @@ func (m *TxnData) Reset()         { *m = TxnData{} }
 func (m *TxnData) String() string { return proto.CompactTextString(m) }
 func (*TxnData) ProtoMessage()    {}
 func (*TxnData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{3}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{3}
 }
 func (m *TxnData) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TxnData.Unmarshal(m, b)
@@ -352,7 +352,7 @@ func (m *Transaction) Reset()         { *m = Transaction{} }
 func (m *Transaction) String() string { return proto.CompactTextString(m) }
 func (*Transaction) ProtoMessage()    {}
 func (*Transaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{4}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{4}
 }
 func (m *Transaction) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Transaction.Unmarshal(m, b)
@@ -393,7 +393,7 @@ func (m *PbftBlockHeader) Reset()         { *m = PbftBlockHeader{} }
 func (m *PbftBlockHeader) String() string { return proto.CompactTextString(m) }
 func (*PbftBlockHeader) ProtoMessage()    {}
 func (*PbftBlockHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{5}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{5}
 }
 func (m *PbftBlockHeader) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PbftBlockHeader.Unmarshal(m, b)
@@ -454,7 +454,7 @@ func (m *PbftBlock) Reset()         { *m = PbftBlock{} }
 func (m *PbftBlock) String() string { return proto.CompactTextString(m) }
 func (*PbftBlock) ProtoMessage()    {}
 func (*PbftBlock) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{6}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{6}
 }
 func (m *PbftBlock) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PbftBlock.Unmarshal(m, b)
@@ -507,7 +507,7 @@ func (m *TrueChain) Reset()         { *m = TrueChain{} }
 func (m *TrueChain) String() string { return proto.CompactTextString(m) }
 func (*TrueChain) ProtoMessage()    {}
 func (*TrueChain) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{7}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{7}
 }
 func (m *TrueChain) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TrueChain.Unmarshal(m, b)
@@ -552,7 +552,7 @@ func (m *GenericResp) Reset()         { *m = GenericResp{} }
 func (m *GenericResp) String() string { return proto.CompactTextString(m) }
 func (*GenericResp) ProtoMessage()    {}
 func (*GenericResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{8}
+	return fileDescriptor_fastchain_c1a2415e71fa52f1, []int{8}
 }
 func (m *GenericResp) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenericResp.Unmarshal(m, b)
@@ -666,9 +666,9 @@ var _FastChain_serviceDesc = grpc.ServiceDesc{
 	Metadata: "fastchain.proto",
 }
 
-func init() { proto.RegisterFile("fastchain.proto", fileDescriptor_fastchain_a2f3fdeaa9c87286) }
+func init() { proto.RegisterFile("fastchain.proto", fileDescriptor_fastchain_c1a2415e71fa52f1) }
 
-var fileDescriptor_fastchain_a2f3fdeaa9c87286 = []byte{
+var fileDescriptor_fastchain_c1a2415e71fa52f1 = []byte{
 	// 630 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x54, 0xcd, 0x6e, 0xdb, 0x38,
 	0x10, 0x5e, 0x59, 0x7f, 0xd6, 0xd8, 0xbb, 0x59, 0x70, 0x83, 0x80, 0x30, 0x16, 0xa8, 0xa1, 0x43,

--- a/pbft/src/pbft-core/fastchain/fastchain.pb.go
+++ b/pbft/src/pbft-core/fastchain/fastchain.pb.go
@@ -24,20 +24,19 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type Request struct {
-	Inner                *Request_Inner        `protobuf:"bytes,1,opt,name=inner,proto3" json:"inner,omitempty"`
-	Dig                  []byte                `protobuf:"bytes,2,opt,name=dig,proto3" json:"dig,omitempty"`
-	Sig                  *Request_MsgSignature `protobuf:"bytes,3,opt,name=sig,proto3" json:"sig,omitempty"`
-	Outer                []byte                `protobuf:"bytes,4,opt,name=outer,proto3" json:"outer,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
-	XXX_unrecognized     []byte                `json:"-"`
-	XXX_sizecache        int32                 `json:"-"`
+	Inner                *Request_Inner `protobuf:"bytes,1,opt,name=inner,proto3" json:"inner,omitempty"`
+	Dig                  []byte         `protobuf:"bytes,2,opt,name=dig,proto3" json:"dig,omitempty"`
+	Outer                []byte         `protobuf:"bytes,3,opt,name=outer,proto3" json:"outer,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
+	XXX_unrecognized     []byte         `json:"-"`
+	XXX_sizecache        int32          `json:"-"`
 }
 
 func (m *Request) Reset()         { *m = Request{} }
 func (m *Request) String() string { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{0}
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{0}
 }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request.Unmarshal(m, b)
@@ -71,13 +70,6 @@ func (m *Request) GetDig() []byte {
 	return nil
 }
 
-func (m *Request) GetSig() *Request_MsgSignature {
-	if m != nil {
-		return m.Sig
-	}
-	return nil
-}
-
 func (m *Request) GetOuter() []byte {
 	if m != nil {
 		return m.Outer
@@ -86,22 +78,22 @@ func (m *Request) GetOuter() []byte {
 }
 
 type Request_Inner struct {
-	Id                   int32    `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
-	Seq                  int32    `protobuf:"varint,2,opt,name=seq,proto3" json:"seq,omitempty"`
-	View                 int32    `protobuf:"varint,3,opt,name=view,proto3" json:"view,omitempty"`
-	Type                 int32    `protobuf:"varint,4,opt,name=type,proto3" json:"type,omitempty"`
-	Msg                  []byte   `protobuf:"bytes,5,opt,name=msg,proto3" json:"msg,omitempty"`
-	Timestamp            int64    `protobuf:"varint,6,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Id                   int32      `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Seq                  int32      `protobuf:"varint,2,opt,name=seq,proto3" json:"seq,omitempty"`
+	View                 int32      `protobuf:"varint,3,opt,name=view,proto3" json:"view,omitempty"`
+	Type                 int32      `protobuf:"varint,4,opt,name=type,proto3" json:"type,omitempty"`
+	Block                *PbftBlock `protobuf:"bytes,5,opt,name=block,proto3" json:"block,omitempty"`
+	Timestamp            int64      `protobuf:"varint,6,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
+	XXX_unrecognized     []byte     `json:"-"`
+	XXX_sizecache        int32      `json:"-"`
 }
 
 func (m *Request_Inner) Reset()         { *m = Request_Inner{} }
 func (m *Request_Inner) String() string { return proto.CompactTextString(m) }
 func (*Request_Inner) ProtoMessage()    {}
 func (*Request_Inner) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{0, 0}
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{0, 0}
 }
 func (m *Request_Inner) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Request_Inner.Unmarshal(m, b)
@@ -149,9 +141,9 @@ func (m *Request_Inner) GetType() int32 {
 	return 0
 }
 
-func (m *Request_Inner) GetMsg() []byte {
+func (m *Request_Inner) GetBlock() *PbftBlock {
 	if m != nil {
-		return m.Msg
+		return m.Block
 	}
 	return nil
 }
@@ -161,120 +153,6 @@ func (m *Request_Inner) GetTimestamp() int64 {
 		return m.Timestamp
 	}
 	return 0
-}
-
-type Request_MsgSignature struct {
-	R                    int64    `protobuf:"varint,1,opt,name=r,proto3" json:"r,omitempty"`
-	S                    int64    `protobuf:"varint,2,opt,name=s,proto3" json:"s,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *Request_MsgSignature) Reset()         { *m = Request_MsgSignature{} }
-func (m *Request_MsgSignature) String() string { return proto.CompactTextString(m) }
-func (*Request_MsgSignature) ProtoMessage()    {}
-func (*Request_MsgSignature) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{0, 1}
-}
-func (m *Request_MsgSignature) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_Request_MsgSignature.Unmarshal(m, b)
-}
-func (m *Request_MsgSignature) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Request_MsgSignature.Marshal(b, m, deterministic)
-}
-func (dst *Request_MsgSignature) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Request_MsgSignature.Merge(dst, src)
-}
-func (m *Request_MsgSignature) XXX_Size() int {
-	return xxx_messageInfo_Request_MsgSignature.Size(m)
-}
-func (m *Request_MsgSignature) XXX_DiscardUnknown() {
-	xxx_messageInfo_Request_MsgSignature.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Request_MsgSignature proto.InternalMessageInfo
-
-func (m *Request_MsgSignature) GetR() int64 {
-	if m != nil {
-		return m.R
-	}
-	return 0
-}
-
-func (m *Request_MsgSignature) GetS() int64 {
-	if m != nil {
-		return m.S
-	}
-	return 0
-}
-
-type CheckLeaderReq struct {
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *CheckLeaderReq) Reset()         { *m = CheckLeaderReq{} }
-func (m *CheckLeaderReq) String() string { return proto.CompactTextString(m) }
-func (*CheckLeaderReq) ProtoMessage()    {}
-func (*CheckLeaderReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{1}
-}
-func (m *CheckLeaderReq) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CheckLeaderReq.Unmarshal(m, b)
-}
-func (m *CheckLeaderReq) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CheckLeaderReq.Marshal(b, m, deterministic)
-}
-func (dst *CheckLeaderReq) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckLeaderReq.Merge(dst, src)
-}
-func (m *CheckLeaderReq) XXX_Size() int {
-	return xxx_messageInfo_CheckLeaderReq.Size(m)
-}
-func (m *CheckLeaderReq) XXX_DiscardUnknown() {
-	xxx_messageInfo_CheckLeaderReq.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_CheckLeaderReq proto.InternalMessageInfo
-
-type CheckLeaderResp struct {
-	Message              bool     `protobuf:"varint,1,opt,name=message,proto3" json:"message,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *CheckLeaderResp) Reset()         { *m = CheckLeaderResp{} }
-func (m *CheckLeaderResp) String() string { return proto.CompactTextString(m) }
-func (*CheckLeaderResp) ProtoMessage()    {}
-func (*CheckLeaderResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{2}
-}
-func (m *CheckLeaderResp) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CheckLeaderResp.Unmarshal(m, b)
-}
-func (m *CheckLeaderResp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CheckLeaderResp.Marshal(b, m, deterministic)
-}
-func (dst *CheckLeaderResp) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CheckLeaderResp.Merge(dst, src)
-}
-func (m *CheckLeaderResp) XXX_Size() int {
-	return xxx_messageInfo_CheckLeaderResp.Size(m)
-}
-func (m *CheckLeaderResp) XXX_DiscardUnknown() {
-	xxx_messageInfo_CheckLeaderResp.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_CheckLeaderResp proto.InternalMessageInfo
-
-func (m *CheckLeaderResp) GetMessage() bool {
-	if m != nil {
-		return m.Message
-	}
-	return false
 }
 
 type PbftNode struct {
@@ -290,7 +168,7 @@ func (m *PbftNode) Reset()         { *m = PbftNode{} }
 func (m *PbftNode) String() string { return proto.CompactTextString(m) }
 func (*PbftNode) ProtoMessage()    {}
 func (*PbftNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{3}
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{1}
 }
 func (m *PbftNode) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PbftNode.Unmarshal(m, b)
@@ -342,7 +220,7 @@ func (m *Nodes) Reset()         { *m = Nodes{} }
 func (m *Nodes) String() string { return proto.CompactTextString(m) }
 func (*Nodes) ProtoMessage()    {}
 func (*Nodes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{4}
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{2}
 }
 func (m *Nodes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Nodes.Unmarshal(m, b)
@@ -369,68 +247,6 @@ func (m *Nodes) GetNodes() []*PbftNode {
 	return nil
 }
 
-type PbftBlockHeader struct {
-	Number               int64    `protobuf:"varint,1,opt,name=Number,json=number,proto3" json:"Number,omitempty"`
-	GasLimit             int64    `protobuf:"varint,2,opt,name=GasLimit,json=gasLimit,proto3" json:"GasLimit,omitempty"`
-	GasUsed              int64    `protobuf:"varint,3,opt,name=GasUsed,json=gasUsed,proto3" json:"GasUsed,omitempty"`
-	Time                 int64    `protobuf:"varint,4,opt,name=Time,json=time,proto3" json:"Time,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *PbftBlockHeader) Reset()         { *m = PbftBlockHeader{} }
-func (m *PbftBlockHeader) String() string { return proto.CompactTextString(m) }
-func (*PbftBlockHeader) ProtoMessage()    {}
-func (*PbftBlockHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{5}
-}
-func (m *PbftBlockHeader) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_PbftBlockHeader.Unmarshal(m, b)
-}
-func (m *PbftBlockHeader) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_PbftBlockHeader.Marshal(b, m, deterministic)
-}
-func (dst *PbftBlockHeader) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PbftBlockHeader.Merge(dst, src)
-}
-func (m *PbftBlockHeader) XXX_Size() int {
-	return xxx_messageInfo_PbftBlockHeader.Size(m)
-}
-func (m *PbftBlockHeader) XXX_DiscardUnknown() {
-	xxx_messageInfo_PbftBlockHeader.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_PbftBlockHeader proto.InternalMessageInfo
-
-func (m *PbftBlockHeader) GetNumber() int64 {
-	if m != nil {
-		return m.Number
-	}
-	return 0
-}
-
-func (m *PbftBlockHeader) GetGasLimit() int64 {
-	if m != nil {
-		return m.GasLimit
-	}
-	return 0
-}
-
-func (m *PbftBlockHeader) GetGasUsed() int64 {
-	if m != nil {
-		return m.GasUsed
-	}
-	return 0
-}
-
-func (m *PbftBlockHeader) GetTime() int64 {
-	if m != nil {
-		return m.Time
-	}
-	return 0
-}
-
 type TxnData struct {
 	AccountNonce         uint64   `protobuf:"varint,1,opt,name=AccountNonce,json=accountNonce,proto3" json:"AccountNonce,omitempty"`
 	Price                int64    `protobuf:"varint,2,opt,name=Price,json=price,proto3" json:"Price,omitempty"`
@@ -438,10 +254,8 @@ type TxnData struct {
 	Recipient            []byte   `protobuf:"bytes,4,opt,name=Recipient,json=recipient,proto3" json:"Recipient,omitempty"`
 	Amount               int64    `protobuf:"varint,5,opt,name=Amount,json=amount,proto3" json:"Amount,omitempty"`
 	Payload              []byte   `protobuf:"bytes,6,opt,name=Payload,json=payload,proto3" json:"Payload,omitempty"`
-	V                    int64    `protobuf:"varint,7,opt,name=V,json=v,proto3" json:"V,omitempty"`
-	R                    int64    `protobuf:"varint,8,opt,name=R,json=r,proto3" json:"R,omitempty"`
-	S                    int64    `protobuf:"varint,9,opt,name=S,json=s,proto3" json:"S,omitempty"`
-	Hash                 []byte   `protobuf:"bytes,10,opt,name=Hash,json=hash,proto3" json:"Hash,omitempty"`
+	Signature            []byte   `protobuf:"bytes,7,opt,name=Signature,json=signature,proto3" json:"Signature,omitempty"`
+	Hash                 []byte   `protobuf:"bytes,8,opt,name=Hash,json=hash,proto3" json:"Hash,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -451,7 +265,7 @@ func (m *TxnData) Reset()         { *m = TxnData{} }
 func (m *TxnData) String() string { return proto.CompactTextString(m) }
 func (*TxnData) ProtoMessage()    {}
 func (*TxnData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{6}
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{3}
 }
 func (m *TxnData) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TxnData.Unmarshal(m, b)
@@ -513,25 +327,11 @@ func (m *TxnData) GetPayload() []byte {
 	return nil
 }
 
-func (m *TxnData) GetV() int64 {
+func (m *TxnData) GetSignature() []byte {
 	if m != nil {
-		return m.V
+		return m.Signature
 	}
-	return 0
-}
-
-func (m *TxnData) GetR() int64 {
-	if m != nil {
-		return m.R
-	}
-	return 0
-}
-
-func (m *TxnData) GetS() int64 {
-	if m != nil {
-		return m.S
-	}
-	return 0
+	return nil
 }
 
 func (m *TxnData) GetHash() []byte {
@@ -552,7 +352,7 @@ func (m *Transaction) Reset()         { *m = Transaction{} }
 func (m *Transaction) String() string { return proto.CompactTextString(m) }
 func (*Transaction) ProtoMessage()    {}
 func (*Transaction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{7}
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{4}
 }
 func (m *Transaction) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Transaction.Unmarshal(m, b)
@@ -579,47 +379,71 @@ func (m *Transaction) GetData() *TxnData {
 	return nil
 }
 
-type Transactions struct {
-	Txns                 []*Transaction `protobuf:"bytes,1,rep,name=txns,proto3" json:"txns,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
-	XXX_unrecognized     []byte         `json:"-"`
-	XXX_sizecache        int32          `json:"-"`
+type PbftBlockHeader struct {
+	Number               int64    `protobuf:"varint,1,opt,name=Number,json=number,proto3" json:"Number,omitempty"`
+	GasLimit             int64    `protobuf:"varint,2,opt,name=GasLimit,json=gasLimit,proto3" json:"GasLimit,omitempty"`
+	GasUsed              int64    `protobuf:"varint,3,opt,name=GasUsed,json=gasUsed,proto3" json:"GasUsed,omitempty"`
+	Time                 int64    `protobuf:"varint,4,opt,name=Time,json=time,proto3" json:"Time,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *Transactions) Reset()         { *m = Transactions{} }
-func (m *Transactions) String() string { return proto.CompactTextString(m) }
-func (*Transactions) ProtoMessage()    {}
-func (*Transactions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{8}
+func (m *PbftBlockHeader) Reset()         { *m = PbftBlockHeader{} }
+func (m *PbftBlockHeader) String() string { return proto.CompactTextString(m) }
+func (*PbftBlockHeader) ProtoMessage()    {}
+func (*PbftBlockHeader) Descriptor() ([]byte, []int) {
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{5}
 }
-func (m *Transactions) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_Transactions.Unmarshal(m, b)
+func (m *PbftBlockHeader) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PbftBlockHeader.Unmarshal(m, b)
 }
-func (m *Transactions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Transactions.Marshal(b, m, deterministic)
+func (m *PbftBlockHeader) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PbftBlockHeader.Marshal(b, m, deterministic)
 }
-func (dst *Transactions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Transactions.Merge(dst, src)
+func (dst *PbftBlockHeader) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PbftBlockHeader.Merge(dst, src)
 }
-func (m *Transactions) XXX_Size() int {
-	return xxx_messageInfo_Transactions.Size(m)
+func (m *PbftBlockHeader) XXX_Size() int {
+	return xxx_messageInfo_PbftBlockHeader.Size(m)
 }
-func (m *Transactions) XXX_DiscardUnknown() {
-	xxx_messageInfo_Transactions.DiscardUnknown(m)
+func (m *PbftBlockHeader) XXX_DiscardUnknown() {
+	xxx_messageInfo_PbftBlockHeader.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_Transactions proto.InternalMessageInfo
+var xxx_messageInfo_PbftBlockHeader proto.InternalMessageInfo
 
-func (m *Transactions) GetTxns() []*Transaction {
+func (m *PbftBlockHeader) GetNumber() int64 {
 	if m != nil {
-		return m.Txns
+		return m.Number
 	}
-	return nil
+	return 0
+}
+
+func (m *PbftBlockHeader) GetGasLimit() int64 {
+	if m != nil {
+		return m.GasLimit
+	}
+	return 0
+}
+
+func (m *PbftBlockHeader) GetGasUsed() int64 {
+	if m != nil {
+		return m.GasUsed
+	}
+	return 0
+}
+
+func (m *PbftBlockHeader) GetTime() int64 {
+	if m != nil {
+		return m.Time
+	}
+	return 0
 }
 
 type PbftBlock struct {
 	Header               *PbftBlockHeader `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
-	Txns                 *Transactions    `protobuf:"bytes,2,opt,name=txns,proto3" json:"txns,omitempty"`
+	Txns                 []*Transaction   `protobuf:"bytes,2,rep,name=txns,proto3" json:"txns,omitempty"`
 	Signs                []string         `protobuf:"bytes,3,rep,name=signs,proto3" json:"signs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
@@ -630,7 +454,7 @@ func (m *PbftBlock) Reset()         { *m = PbftBlock{} }
 func (m *PbftBlock) String() string { return proto.CompactTextString(m) }
 func (*PbftBlock) ProtoMessage()    {}
 func (*PbftBlock) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{9}
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{6}
 }
 func (m *PbftBlock) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PbftBlock.Unmarshal(m, b)
@@ -657,7 +481,7 @@ func (m *PbftBlock) GetHeader() *PbftBlockHeader {
 	return nil
 }
 
-func (m *PbftBlock) GetTxns() *Transactions {
+func (m *PbftBlock) GetTxns() []*Transaction {
 	if m != nil {
 		return m.Txns
 	}
@@ -667,6 +491,52 @@ func (m *PbftBlock) GetTxns() *Transactions {
 func (m *PbftBlock) GetSigns() []string {
 	if m != nil {
 		return m.Signs
+	}
+	return nil
+}
+
+type TrueChain struct {
+	Blocks               []*PbftBlock     `protobuf:"bytes,1,rep,name=blocks,proto3" json:"blocks,omitempty"`
+	Lastheader           *PbftBlockHeader `protobuf:"bytes,2,opt,name=lastheader,proto3" json:"lastheader,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
+	XXX_unrecognized     []byte           `json:"-"`
+	XXX_sizecache        int32            `json:"-"`
+}
+
+func (m *TrueChain) Reset()         { *m = TrueChain{} }
+func (m *TrueChain) String() string { return proto.CompactTextString(m) }
+func (*TrueChain) ProtoMessage()    {}
+func (*TrueChain) Descriptor() ([]byte, []int) {
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{7}
+}
+func (m *TrueChain) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_TrueChain.Unmarshal(m, b)
+}
+func (m *TrueChain) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_TrueChain.Marshal(b, m, deterministic)
+}
+func (dst *TrueChain) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TrueChain.Merge(dst, src)
+}
+func (m *TrueChain) XXX_Size() int {
+	return xxx_messageInfo_TrueChain.Size(m)
+}
+func (m *TrueChain) XXX_DiscardUnknown() {
+	xxx_messageInfo_TrueChain.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_TrueChain proto.InternalMessageInfo
+
+func (m *TrueChain) GetBlocks() []*PbftBlock {
+	if m != nil {
+		return m.Blocks
+	}
+	return nil
+}
+
+func (m *TrueChain) GetLastheader() *PbftBlockHeader {
+	if m != nil {
+		return m.Lastheader
 	}
 	return nil
 }
@@ -682,7 +552,7 @@ func (m *GenericResp) Reset()         { *m = GenericResp{} }
 func (m *GenericResp) String() string { return proto.CompactTextString(m) }
 func (*GenericResp) ProtoMessage()    {}
 func (*GenericResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_fastchain_814080330dbc71d2, []int{10}
+	return fileDescriptor_fastchain_a2f3fdeaa9c87286, []int{8}
 }
 func (m *GenericResp) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenericResp.Unmarshal(m, b)
@@ -712,16 +582,13 @@ func (m *GenericResp) GetMsg() string {
 func init() {
 	proto.RegisterType((*Request)(nil), "fastchain.Request")
 	proto.RegisterType((*Request_Inner)(nil), "fastchain.Request.Inner")
-	proto.RegisterType((*Request_MsgSignature)(nil), "fastchain.Request.MsgSignature")
-	proto.RegisterType((*CheckLeaderReq)(nil), "fastchain.CheckLeaderReq")
-	proto.RegisterType((*CheckLeaderResp)(nil), "fastchain.CheckLeaderResp")
 	proto.RegisterType((*PbftNode)(nil), "fastchain.PbftNode")
 	proto.RegisterType((*Nodes)(nil), "fastchain.Nodes")
-	proto.RegisterType((*PbftBlockHeader)(nil), "fastchain.PbftBlockHeader")
 	proto.RegisterType((*TxnData)(nil), "fastchain.TxnData")
 	proto.RegisterType((*Transaction)(nil), "fastchain.Transaction")
-	proto.RegisterType((*Transactions)(nil), "fastchain.Transactions")
+	proto.RegisterType((*PbftBlockHeader)(nil), "fastchain.PbftBlockHeader")
 	proto.RegisterType((*PbftBlock)(nil), "fastchain.PbftBlock")
+	proto.RegisterType((*TrueChain)(nil), "fastchain.TrueChain")
 	proto.RegisterType((*GenericResp)(nil), "fastchain.GenericResp")
 }
 
@@ -737,10 +604,8 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type FastChainClient interface {
-	// RPC service that responds whether the node is the leader
-	CheckLeader(ctx context.Context, in *CheckLeaderReq, opts ...grpc.CallOption) (*CheckLeaderResp, error)
 	// Send new transaction to presumed leader node
-	NewTxnRequest(ctx context.Context, in *Request, opts ...grpc.CallOption) (*GenericResp, error)
+	NewTxnRequest(ctx context.Context, in *Transaction, opts ...grpc.CallOption) (*GenericResp, error)
 }
 
 type fastChainClient struct {
@@ -751,16 +616,7 @@ func NewFastChainClient(cc *grpc.ClientConn) FastChainClient {
 	return &fastChainClient{cc}
 }
 
-func (c *fastChainClient) CheckLeader(ctx context.Context, in *CheckLeaderReq, opts ...grpc.CallOption) (*CheckLeaderResp, error) {
-	out := new(CheckLeaderResp)
-	err := c.cc.Invoke(ctx, "/fastchain.FastChain/CheckLeader", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *fastChainClient) NewTxnRequest(ctx context.Context, in *Request, opts ...grpc.CallOption) (*GenericResp, error) {
+func (c *fastChainClient) NewTxnRequest(ctx context.Context, in *Transaction, opts ...grpc.CallOption) (*GenericResp, error) {
 	out := new(GenericResp)
 	err := c.cc.Invoke(ctx, "/fastchain.FastChain/NewTxnRequest", in, out, opts...)
 	if err != nil {
@@ -771,36 +627,16 @@ func (c *fastChainClient) NewTxnRequest(ctx context.Context, in *Request, opts .
 
 // FastChainServer is the server API for FastChain service.
 type FastChainServer interface {
-	// RPC service that responds whether the node is the leader
-	CheckLeader(context.Context, *CheckLeaderReq) (*CheckLeaderResp, error)
 	// Send new transaction to presumed leader node
-	NewTxnRequest(context.Context, *Request) (*GenericResp, error)
+	NewTxnRequest(context.Context, *Transaction) (*GenericResp, error)
 }
 
 func RegisterFastChainServer(s *grpc.Server, srv FastChainServer) {
 	s.RegisterService(&_FastChain_serviceDesc, srv)
 }
 
-func _FastChain_CheckLeader_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CheckLeaderReq)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(FastChainServer).CheckLeader(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/fastchain.FastChain/CheckLeader",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(FastChainServer).CheckLeader(ctx, req.(*CheckLeaderReq))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _FastChain_NewTxnRequest_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(Request)
+	in := new(Transaction)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -812,7 +648,7 @@ func _FastChain_NewTxnRequest_Handler(srv interface{}, ctx context.Context, dec 
 		FullMethod: "/fastchain.FastChain/NewTxnRequest",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(FastChainServer).NewTxnRequest(ctx, req.(*Request))
+		return srv.(FastChainServer).NewTxnRequest(ctx, req.(*Transaction))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -822,10 +658,6 @@ var _FastChain_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*FastChainServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "CheckLeader",
-			Handler:    _FastChain_CheckLeader_Handler,
-		},
-		{
 			MethodName: "NewTxnRequest",
 			Handler:    _FastChain_NewTxnRequest_Handler,
 		},
@@ -834,52 +666,48 @@ var _FastChain_serviceDesc = grpc.ServiceDesc{
 	Metadata: "fastchain.proto",
 }
 
-func init() { proto.RegisterFile("fastchain.proto", fileDescriptor_fastchain_814080330dbc71d2) }
+func init() { proto.RegisterFile("fastchain.proto", fileDescriptor_fastchain_a2f3fdeaa9c87286) }
 
-var fileDescriptor_fastchain_814080330dbc71d2 = []byte{
-	// 703 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x54, 0x5f, 0x6f, 0xd3, 0x30,
-	0x10, 0x5f, 0x9a, 0xa6, 0x6d, 0xae, 0x65, 0x9b, 0x0c, 0x1a, 0xa1, 0x9a, 0xb4, 0xca, 0x0f, 0xa8,
-	0x6c, 0x52, 0x25, 0x8a, 0x78, 0x41, 0xe2, 0x61, 0x0c, 0x6d, 0x43, 0x1a, 0x55, 0xe5, 0x15, 0xde,
-	0xdd, 0xc4, 0x4b, 0xad, 0x2d, 0x4e, 0x16, 0xbb, 0xfb, 0xf3, 0x08, 0x1f, 0x81, 0xcf, 0xc4, 0xd7,
-	0xe1, 0x3b, 0xa0, 0xb3, 0xd3, 0x2d, 0x1b, 0xe3, 0xed, 0x7e, 0xe7, 0xbb, 0xfb, 0xfd, 0x7c, 0x77,
-	0x36, 0x6c, 0x9c, 0x71, 0x6d, 0xe2, 0x05, 0x97, 0x6a, 0x54, 0x94, 0xb9, 0xc9, 0x49, 0x78, 0xe7,
-	0xa0, 0xbf, 0x1b, 0xd0, 0x66, 0xe2, 0x72, 0x29, 0xb4, 0x21, 0x23, 0x08, 0xa4, 0x52, 0xa2, 0x8c,
-	0xbc, 0x81, 0x37, 0xec, 0x8e, 0xa3, 0xd1, 0x7d, 0x5e, 0x15, 0x32, 0xfa, 0x82, 0xe7, 0xcc, 0x85,
-	0x91, 0x4d, 0xf0, 0x13, 0x99, 0x46, 0x8d, 0x81, 0x37, 0xec, 0x31, 0x34, 0xc9, 0x5b, 0xf0, 0xb5,
-	0x4c, 0x23, 0xdf, 0xe6, 0xef, 0x3c, 0x91, 0xff, 0x55, 0xa7, 0xa7, 0x32, 0x55, 0xdc, 0x2c, 0x4b,
-	0xc1, 0x30, 0x96, 0xbc, 0x80, 0x20, 0x5f, 0x1a, 0x51, 0x46, 0x4d, 0x5b, 0xc6, 0x81, 0xfe, 0x0f,
-	0x0f, 0x02, 0xcb, 0x45, 0xd6, 0xa1, 0x21, 0x13, 0xab, 0x28, 0x60, 0x0d, 0x99, 0x20, 0xa9, 0x16,
-	0x97, 0x96, 0x34, 0x60, 0x68, 0x12, 0x02, 0xcd, 0x2b, 0x29, 0xae, 0x2d, 0x6b, 0xc0, 0xac, 0x8d,
-	0x3e, 0x73, 0x5b, 0x08, 0x5b, 0x34, 0x60, 0xd6, 0xc6, 0xcc, 0x4c, 0xa7, 0x51, 0xe0, 0xe4, 0x66,
-	0x3a, 0x25, 0xdb, 0x10, 0x1a, 0x99, 0x09, 0x6d, 0x78, 0x56, 0x44, 0xad, 0x81, 0x37, 0xf4, 0xd9,
-	0xbd, 0xa3, 0xbf, 0x0b, 0xbd, 0xba, 0x5c, 0xd2, 0x03, 0xcf, 0xb5, 0xc6, 0x67, 0x5e, 0x89, 0x48,
-	0x5b, 0x15, 0x3e, 0xf3, 0x34, 0xdd, 0x84, 0xf5, 0x83, 0x85, 0x88, 0xcf, 0x4f, 0x04, 0x4f, 0x44,
-	0xc9, 0xc4, 0x25, 0xdd, 0x83, 0x8d, 0x07, 0x1e, 0x5d, 0x90, 0x08, 0xda, 0x99, 0xd0, 0x9a, 0xa7,
-	0xc2, 0x96, 0xe9, 0xb0, 0x15, 0xa4, 0x53, 0xe8, 0x4c, 0xe7, 0x67, 0x66, 0x92, 0x27, 0x02, 0xa5,
-	0xf3, 0x24, 0x71, 0x4c, 0x21, 0xb3, 0x36, 0xd9, 0x82, 0x56, 0xb1, 0x9c, 0x9f, 0x8b, 0x5b, 0xcb,
-	0x18, 0xb2, 0x0a, 0x61, 0xc5, 0xa2, 0x94, 0x57, 0x78, 0xe0, 0xdb, 0x83, 0x15, 0xa4, 0x63, 0x08,
-	0xb0, 0x9a, 0x26, 0x6f, 0x20, 0x50, 0x68, 0x44, 0xde, 0xc0, 0x1f, 0x76, 0xc7, 0xcf, 0x6b, 0x43,
-	0x59, 0x51, 0x32, 0x17, 0x41, 0x35, 0x6c, 0xa0, 0xeb, 0xd3, 0x45, 0x1e, 0x9f, 0x1f, 0x5b, 0xd9,
-	0x48, 0x3c, 0x59, 0x66, 0x73, 0xb1, 0xba, 0x78, 0x4b, 0x59, 0x44, 0xfa, 0xd0, 0x39, 0xe2, 0xfa,
-	0x44, 0x66, 0xd2, 0x54, 0x4d, 0xe8, 0xa4, 0x15, 0x46, 0x51, 0x47, 0x5c, 0x7f, 0xd3, 0x22, 0xb1,
-	0xa2, 0x7c, 0xd6, 0x4e, 0x1d, 0xc4, 0xab, 0xcd, 0x64, 0xe6, 0xa6, 0xe2, 0xb3, 0x26, 0xb6, 0x9a,
-	0xfe, 0xf1, 0xa0, 0x3d, 0xbb, 0x51, 0x9f, 0xb9, 0xe1, 0x84, 0x42, 0x6f, 0x3f, 0x8e, 0xf3, 0xa5,
-	0x32, 0x93, 0x5c, 0xc5, 0xae, 0x4b, 0x4d, 0xd6, 0xe3, 0x35, 0x1f, 0xee, 0xcb, 0xb4, 0x94, 0xb1,
-	0xa8, 0x68, 0x83, 0x02, 0xc1, 0x03, 0x3d, 0xfe, 0x23, 0x3d, 0xdb, 0x10, 0x32, 0x11, 0xcb, 0x42,
-	0x0a, 0x65, 0xaa, 0x2d, 0x0b, 0xcb, 0x95, 0x03, 0x6f, 0xb8, 0x9f, 0x61, 0x79, 0xbb, 0x18, 0x3e,
-	0x6b, 0x71, 0x8b, 0xf0, 0x16, 0x53, 0x7e, 0x7b, 0x91, 0xf3, 0xc4, 0x6e, 0x46, 0x8f, 0xb5, 0x0b,
-	0x07, 0x71, 0xf2, 0xdf, 0xa3, 0xb6, 0x9b, 0xfc, 0x15, 0x22, 0x16, 0x75, 0x6a, 0x5b, 0x71, 0x1a,
-	0x85, 0xd5, 0x56, 0xe0, 0x7d, 0x8f, 0xb9, 0x5e, 0x44, 0x60, 0x0b, 0x34, 0x17, 0x5c, 0x2f, 0xe8,
-	0x7b, 0xe8, 0xce, 0x4a, 0xae, 0x34, 0x8f, 0x8d, 0xcc, 0x15, 0x79, 0x0d, 0xcd, 0x84, 0x1b, 0x5e,
-	0x3d, 0x39, 0x52, 0x9b, 0x4e, 0xd5, 0x14, 0x66, 0xcf, 0xe9, 0x07, 0xe8, 0xd5, 0xd2, 0x34, 0xd9,
-	0x85, 0xa6, 0xb9, 0x51, 0xab, 0xa9, 0x6e, 0xd5, 0xf3, 0xee, 0xc3, 0x98, 0x8d, 0xa1, 0x3f, 0x3d,
-	0x08, 0xef, 0x06, 0x4b, 0xc6, 0xd0, 0x5a, 0xd8, 0xe1, 0x56, 0x9c, 0xfd, 0x47, 0x1b, 0x51, 0x1b,
-	0x3f, 0xab, 0x22, 0xc9, 0x5e, 0xc5, 0xd6, 0xb0, 0x19, 0x2f, 0x9f, 0x66, 0xd3, 0x8e, 0x0e, 0x27,
-	0xa4, 0x65, 0xaa, 0x74, 0xe4, 0x0f, 0xfc, 0x61, 0xc8, 0x1c, 0xa0, 0x3b, 0xd0, 0x3d, 0x12, 0x4a,
-	0x94, 0x32, 0xb6, 0x6f, 0xa1, 0x7a, 0x8c, 0x6e, 0xc9, 0xd1, 0x1c, 0xff, 0xf2, 0x20, 0x3c, 0xe4,
-	0xda, 0x1c, 0x60, 0x5d, 0x72, 0x08, 0xdd, 0xda, 0xf3, 0x21, 0xaf, 0x6a, 0x94, 0x0f, 0x1f, 0x5a,
-	0xbf, 0xff, 0xbf, 0x23, 0x5d, 0xd0, 0x35, 0xf2, 0x11, 0x9e, 0x4d, 0xc4, 0xf5, 0xec, 0x46, 0xad,
-	0x3e, 0x39, 0xf2, 0xef, 0xaf, 0xd4, 0xaf, 0xb7, 0xaf, 0x26, 0x92, 0xae, 0xcd, 0x5b, 0xf6, 0xc3,
-	0x7c, 0xf7, 0x37, 0x00, 0x00, 0xff, 0xff, 0xcb, 0x39, 0x05, 0x25, 0x43, 0x05, 0x00, 0x00,
+var fileDescriptor_fastchain_a2f3fdeaa9c87286 = []byte{
+	// 630 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x84, 0x54, 0xcd, 0x6e, 0xdb, 0x38,
+	0x10, 0x5e, 0x59, 0x7f, 0xd6, 0xd8, 0xbb, 0x59, 0x70, 0x83, 0x80, 0x30, 0x16, 0xa8, 0xa1, 0x43,
+	0xe1, 0x06, 0x85, 0x0f, 0x2e, 0x7a, 0xe9, 0x2d, 0x6d, 0xd1, 0xa4, 0x40, 0x61, 0x18, 0xac, 0xfb,
+	0x00, 0xb4, 0xc4, 0xd8, 0x44, 0x22, 0x4a, 0x11, 0xa9, 0xfc, 0x1c, 0xfb, 0x1c, 0x7d, 0xba, 0x3e,
+	0x49, 0x8b, 0x19, 0xc9, 0x89, 0x1a, 0xa4, 0xe8, 0x6d, 0xbe, 0x99, 0xe1, 0xc7, 0x6f, 0x3e, 0x8e,
+	0x04, 0x07, 0xe7, 0xd2, 0xba, 0x6c, 0x27, 0xb5, 0x99, 0x57, 0x75, 0xe9, 0x4a, 0x96, 0xdc, 0x27,
+	0xd2, 0x1f, 0x1e, 0xc4, 0x42, 0x5d, 0x35, 0xca, 0x3a, 0x36, 0x87, 0x50, 0x1b, 0xa3, 0x6a, 0xee,
+	0x4d, 0xbd, 0xd9, 0x68, 0xc1, 0xe7, 0x0f, 0xe7, 0xba, 0x96, 0xf9, 0x47, 0xac, 0x8b, 0xb6, 0x8d,
+	0xfd, 0x0b, 0x7e, 0xae, 0xb7, 0x7c, 0x30, 0xf5, 0x66, 0x63, 0x81, 0x21, 0x3b, 0x84, 0xb0, 0x6c,
+	0x9c, 0xaa, 0xb9, 0x4f, 0xb9, 0x16, 0x4c, 0xbe, 0x79, 0x10, 0xd2, 0x41, 0xf6, 0x0f, 0x0c, 0x74,
+	0x4e, 0xf4, 0xa1, 0x18, 0xe8, 0x1c, 0x19, 0xac, 0xba, 0x22, 0x86, 0x50, 0x60, 0xc8, 0x18, 0x04,
+	0xd7, 0x5a, 0xdd, 0x10, 0x41, 0x28, 0x28, 0xc6, 0x9c, 0xbb, 0xab, 0x14, 0x0f, 0xda, 0x1c, 0xc6,
+	0xec, 0x18, 0xc2, 0xcd, 0x65, 0x99, 0x5d, 0xf0, 0x90, 0xb4, 0x1e, 0xf6, 0xb4, 0xae, 0x36, 0xe7,
+	0xee, 0x2d, 0xd6, 0x44, 0xdb, 0xc2, 0xfe, 0x87, 0xc4, 0xe9, 0x42, 0x59, 0x27, 0x8b, 0x8a, 0x47,
+	0x53, 0x6f, 0xe6, 0x8b, 0x87, 0x44, 0xba, 0x82, 0x21, 0x9e, 0x58, 0x96, 0xb9, 0xc2, 0x9b, 0x64,
+	0x9e, 0xb7, 0x06, 0x24, 0x82, 0x62, 0x76, 0x04, 0x51, 0xd5, 0x6c, 0x2e, 0xd4, 0x1d, 0xc9, 0x4c,
+	0x44, 0x87, 0x18, 0x87, 0xb8, 0xaa, 0xf5, 0x35, 0x16, 0x7c, 0x2a, 0xec, 0x61, 0xba, 0x80, 0x10,
+	0xd9, 0x2c, 0x7b, 0x01, 0xa1, 0xc1, 0x80, 0x7b, 0x53, 0x7f, 0x36, 0x5a, 0xfc, 0xf7, 0x48, 0x24,
+	0x36, 0x89, 0xb6, 0x23, 0xfd, 0xee, 0x41, 0xbc, 0xbe, 0x35, 0xef, 0xa5, 0x93, 0x2c, 0x85, 0xf1,
+	0x49, 0x96, 0x95, 0x8d, 0x71, 0xcb, 0xd2, 0x64, 0x8a, 0xd4, 0x04, 0x62, 0x2c, 0x7b, 0x39, 0x74,
+	0x7a, 0x55, 0xeb, 0x4c, 0x91, 0x28, 0x5f, 0x84, 0x15, 0x02, 0x36, 0x81, 0xe1, 0xa9, 0xb4, 0x9f,
+	0x74, 0xa1, 0x1d, 0x89, 0xf2, 0xc5, 0x70, 0xdb, 0x61, 0x74, 0x41, 0xa8, 0x4c, 0x57, 0x5a, 0x19,
+	0x47, 0x56, 0x8e, 0x45, 0x52, 0xef, 0x13, 0x38, 0xe5, 0x49, 0x81, 0xf4, 0x64, 0xa8, 0x2f, 0x22,
+	0x49, 0x08, 0xa7, 0x5c, 0xc9, 0xbb, 0xcb, 0x52, 0xe6, 0xe4, 0xdc, 0x58, 0xc4, 0x55, 0x0b, 0x91,
+	0xef, 0xb3, 0xde, 0x1a, 0xe9, 0x9a, 0x5a, 0xf1, 0xb8, 0xe5, 0xb3, 0xfb, 0x04, 0x3a, 0x79, 0x26,
+	0xed, 0x8e, 0x0f, 0xa9, 0x10, 0xec, 0xa4, 0xdd, 0xa5, 0xaf, 0x61, 0xb4, 0xae, 0xa5, 0xb1, 0x32,
+	0x73, 0xba, 0x34, 0xec, 0x39, 0x04, 0xb9, 0x74, 0xb2, 0xdb, 0x36, 0xd6, 0x33, 0xa7, 0x33, 0x42,
+	0x50, 0x3d, 0xb5, 0x70, 0x70, 0xff, 0xa4, 0x67, 0x4a, 0xe6, 0x8a, 0xde, 0x64, 0xd9, 0x14, 0x9b,
+	0x6e, 0x55, 0x7d, 0x11, 0x19, 0x42, 0xbf, 0xcc, 0x3f, 0x78, 0x34, 0x3f, 0x87, 0xf8, 0x54, 0xda,
+	0x2f, 0x56, 0xe5, 0x9d, 0x35, 0xf1, 0xb6, 0x85, 0xa8, 0x75, 0xad, 0x8b, 0x76, 0xbf, 0x7c, 0x11,
+	0xe0, 0x6a, 0xa4, 0x5f, 0x3d, 0x48, 0xee, 0x6f, 0x65, 0x0b, 0x88, 0x76, 0x74, 0x73, 0x27, 0x76,
+	0xf2, 0xd4, 0xba, 0xb5, 0xda, 0x44, 0xd7, 0xc9, 0x8e, 0x21, 0x70, 0xb7, 0xc6, 0xf2, 0x01, 0xbd,
+	0xfd, 0x51, 0x7f, 0xbc, 0x07, 0x13, 0x04, 0xf5, 0xe0, 0x6b, 0xa2, 0x75, 0x96, 0xfb, 0x53, 0x7f,
+	0x96, 0x88, 0x16, 0xa4, 0x0d, 0x24, 0xeb, 0xba, 0x51, 0xef, 0xf0, 0x10, 0x7b, 0x09, 0x11, 0x6d,
+	0xf3, 0x7e, 0x99, 0x9e, 0xde, 0xf8, 0xae, 0x87, 0xbd, 0x01, 0xb8, 0x94, 0xd6, 0x75, 0xa2, 0x07,
+	0x7f, 0x14, 0xdd, 0xeb, 0x4e, 0x9f, 0xc1, 0xe8, 0x54, 0x19, 0x55, 0xeb, 0x4c, 0x28, 0x5b, 0xe1,
+	0x37, 0x5a, 0xd8, 0x6d, 0xf7, 0x49, 0x60, 0xb8, 0x58, 0x42, 0xf2, 0x41, 0x5a, 0xd7, 0xea, 0x3a,
+	0x81, 0xbf, 0x97, 0xea, 0x66, 0x7d, 0x6b, 0xf6, 0x7f, 0x91, 0xdf, 0x4c, 0x3a, 0xe9, 0xe7, 0x7b,
+	0xfc, 0xe9, 0x5f, 0x9b, 0x88, 0xfe, 0x4a, 0xaf, 0x7e, 0x06, 0x00, 0x00, 0xff, 0xff, 0xbe, 0x4d,
+	0xef, 0xb2, 0xa8, 0x04, 0x00, 0x00,
 }

--- a/pbft/src/pbft-core/fastchain/fastchain.proto
+++ b/pbft/src/pbft-core/fastchain/fastchain.proto
@@ -34,17 +34,18 @@ message Nodes {
 }
 
 message TxnData {
-    uint64 AccountNonce       	 = 1;
-    int64  Price 	     	 = 2;
-    int64  GasLimit		 = 3;
-    bytes  Recipient		 = 4;
-    int64  Amount 		 = 5;
-    bytes  Payload		 = 6;
-    bytes  Signature             = 7;
-    bytes  Hash			 = 8;
+    uint64 AccountNonce = 1;
+    int64  Price        = 2;
+    int64  GasLimit     = 3;
+    bytes  Recipient    = 4;
+    int64  Amount       = 5;
+    bytes  Payload      = 6;
+    bytes  Signature    = 7;
+    bytes  Hash         = 8;
 }
+
 message Transaction {
-    TxnData data 		 = 1;
+    TxnData data        = 1;
 }
 
 message PbftBlockHeader {

--- a/pbft/src/pbft-core/fastchain/fastchain.proto
+++ b/pbft/src/pbft-core/fastchain/fastchain.proto
@@ -4,36 +4,23 @@ package fastchain;
 
 //Interface exposed by pbft committee nodes
 service FastChain {
-        //RPC service that responds whether the node is the leader
-        rpc CheckLeader (CheckLeaderReq) returns (CheckLeaderResp) {}
-        
         //Send new transaction to presumed leader node
-        rpc NewTxnRequest (Request) returns (GenericResp) {}
+        rpc NewTxnRequest (Transaction) returns (GenericResp) {}
 }
 
 message Request {
     message Inner {
-        int32 id        = 1;
-        int32 seq       = 2;
-        int32 view      = 3;
-        int32 type      = 4;
-        bytes msg       = 5;
-        int64 timestamp = 6;
-    }
-    message MsgSignature {
-            int64 r = 1;
-            int64 s = 2;
+        int32 id                = 1;
+        int32 seq               = 2;
+        int32 view              = 3;
+        int32 type              = 4;
+        PbftBlock block         = 5;
+        int64 timestamp         = 6;
     }
 
     Inner inner         = 1;
     bytes dig           = 2;
-    MsgSignature sig    = 3;
-    bytes outer         = 4;
-}
-
-message CheckLeaderReq {}
-message CheckLeaderResp {
-        bool message = 1;
+    bytes outer         = 3;
 }
 
 message PbftNode {
@@ -46,12 +33,6 @@ message Nodes {
     repeated PbftNode nodes = 1;
 }
 
-message PbftBlockHeader {
-    int64  Number 	= 1;
-    int64  GasLimit     = 2;
-    int64  GasUsed	= 3;
-    int64  Time		= 4;
-}
 message TxnData {
     uint64 AccountNonce       	 = 1;
     int64  Price 	     	 = 2;
@@ -59,25 +40,29 @@ message TxnData {
     bytes  Recipient		 = 4;
     int64  Amount 		 = 5;
     bytes  Payload		 = 6;
-    
-    int64  V 			 = 7;
-    int64  R			 = 8;
-    int64  S			 = 9;
-
-    bytes Hash			 = 10;
+    bytes  Signature             = 7;
+    bytes  Hash			 = 8;
 }
 message Transaction {
     TxnData data 		 = 1;
 }
 
-message Transactions {
-    repeated Transaction txns = 1;
+message PbftBlockHeader {
+    int64  Number 	= 1;
+    int64  GasLimit     = 2;
+    int64  GasUsed	= 3;
+    int64  Time		= 4;
 }
 
 message PbftBlock {
-    PbftBlockHeader   header    = 1;
-    Transactions      txns      = 2;
-    repeated string   signs     = 3;   
+    PbftBlockHeader             header  = 1;
+    repeated Transaction        txns    = 2;
+    repeated string             signs   = 3;   
+}
+
+message TrueChain {
+        repeated PbftBlock blocks       = 1;
+        PbftBlockHeader lastheader      = 2;
 }
 
 message GenericResp {

--- a/pbft/src/pbft-core/genkeys.go
+++ b/pbft/src/pbft-core/genkeys.go
@@ -17,19 +17,17 @@ limitations under the License.
 package pbft
 
 import (
-	// "bytes"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
-	// "encoding/pem"
-	// "crypto/x509"
-	// "encoding/gob"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
 // GetCWD provides the current work dir's absolute filepath,
@@ -42,27 +40,21 @@ func GetCWD() string {
 	return dir
 }
 
-// func encode(privateKey *ecdsa.PrivateKey, publicKey *ecdsa.PublicKey) ([]byte, []byte) {
-// 		x509Encoded, _ := x509.MarshalECPrivateKey(privateKey)
-// 		pemEncoded := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x509Encoded})
-// 		x509EncodedPub, _ := x509.MarshalPKIXPublicKey(publicKey)
-// 		pemEncodedPub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x509EncodedPub})
-//     return []byte(pemEncoded), []byte(pemEncodedPub)
-// }
-
 // WriteNewKeys generates kcount # of ECDSA public-private key pairs and writes them
 // into a folder kdir.
 func WriteNewKeys(kcount int, kdir string) {
 	for k := 0; k < kcount; k++ {
-		privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		privateKey, _ := ecdsa.GenerateKey(ethcrypto.S256(), rand.Reader)
 		publicKey := &privateKey.PublicKey
-		pemEncoded, pemEncodedPub := EncodeECDSAKeys(privateKey, publicKey)
+
+		pemEncoded := hex.EncodeToString(ethcrypto.FromECDSA(privateKey))
+		pemEncodedPub := hex.EncodeToString(ethcrypto.FromECDSAPub(publicKey))
 
 		pemkeyFname := fmt.Sprintf("sign%v.pem", k)
-		err1 := ioutil.WriteFile(path.Join(kdir, pemkeyFname), pemEncoded, 0644)
+		err1 := ioutil.WriteFile(path.Join(kdir, pemkeyFname), []byte(pemEncoded), 0600)
 		CheckErr(err1)
 		pubkeyFname := fmt.Sprintf("sign%v.pub", k)
-		err2 := ioutil.WriteFile(path.Join(kdir, pubkeyFname), pemEncodedPub, 0644)
+		err2 := ioutil.WriteFile(path.Join(kdir, pubkeyFname), []byte(pemEncodedPub), 0644)
 		CheckErr(err2)
 	}
 }

--- a/pbft/src/pbft-core/pbft-sim-engine/pbftserverengine.go
+++ b/pbft/src/pbft-core/pbft-sim-engine/pbftserverengine.go
@@ -33,16 +33,6 @@ var (
 	svList []*pbftserver.PbftServer
 )
 
-// LoadPbftSimConfig loads configuration for running PBFT simulation
-/*func LoadPbftSimConfig() {
-	cfg.HostsFile = path.Join(os.Getenv("HOME"), "hosts") // TODO: read from config.yaml in future.
-	cfg.IPList, cfg.Ports, cfg.GrpcPorts = pbft.GetIPConfigs(cfg.HostsFile)
-	cfg.NumKeys = len(cfg.IPList)
-	cfg.N = cfg.NumKeys - 1 // we assume client count to be 1
-	cfg.NumQuest = 100
-	cfg.GenerateKeysToFile(cfg.NumKeys)
-}*/
-
 // StartPbftServers starts PBFT servers from config information
 func StartPbftServers() {
 	svList = make([]*pbftserver.PbftServer, cfg.N)

--- a/pbft/src/pbft-core/pbft-sim-engine/pbftserverengine.go
+++ b/pbft/src/pbft-core/pbft-sim-engine/pbftserverengine.go
@@ -56,6 +56,7 @@ func StartPbftServers() {
 
 func main() {
 	cfg.LoadPbftSimConfig()
+	cfg.GenerateKeysToFile(cfg.NumKeys)
 	StartPbftServers()
 
 	finish := make(chan bool)

--- a/pbft/src/pbft-core/utils.go
+++ b/pbft/src/pbft-core/utils.go
@@ -20,16 +20,14 @@ import (
 	"crypto/ecdsa"
 	"io/ioutil"
 
-	"github.com/fatih/color"
-	// "encoding/hex"
-	// "crypto/rand"
 	"crypto/x509"
-	// "github.com/ethereum/go-ethereum/common/math"
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"github.com/fatih/color"
+	"io"
 	"os"
 	"strings"
-	// "io"
 )
 
 // MyPrint provides customized colored output functionality
@@ -79,6 +77,26 @@ func MakeDirIfNot(dir string) {
 		err := os.Mkdir(dir, 0750)
 		CheckErr(err)
 	}
+}
+
+// FetchPublicKeyBytes fetches ECDSA public key in []byte form
+func FetchPublicKeyBytes(kpath string) ([]byte, error) {
+	buf := make([]byte, 130) //  encoded key length is 1 + 2 * byteLen(publicKey). Also buf len should be even
+	fd, err := os.Open(kpath)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+	if _, err := io.ReadFull(fd, buf); err != nil {
+		return nil, err
+	}
+
+	key, err := hex.DecodeString(string(buf))
+	if err != nil {
+		return nil, err
+	}
+
+	return key, nil
 }
 
 // FetchPublicKey reads and decodes a public key from file stored on disk

--- a/pbft/src/vendor/manifest
+++ b/pbft/src/vendor/manifest
@@ -187,6 +187,51 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/ethereum/go-ethereum/common",
+			"repository": "https://github.com/ethereum/go-ethereum",
+			"vcs": "git",
+			"revision": "eaff89291ce998ba4bf9b9816ca8a15c8b85f440",
+			"branch": "master",
+			"path": "common",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/ethereum/go-ethereum/crypto",
+			"repository": "https://github.com/ethereum/go-ethereum",
+			"vcs": "git",
+			"revision": "eaff89291ce998ba4bf9b9816ca8a15c8b85f440",
+			"branch": "master",
+			"path": "/crypto",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/ethereum/go-ethereum/rlp",
+			"repository": "https://github.com/ethereum/go-ethereum",
+			"vcs": "git",
+			"revision": "eaff89291ce998ba4bf9b9816ca8a15c8b85f440",
+			"branch": "master",
+			"path": "rlp",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/ethereum/go-ethereum/vendor/github.com/aristanetworks/goarista/monotime",
+			"repository": "https://github.com/ethereum/go-ethereum",
+			"vcs": "git",
+			"revision": "eaff89291ce998ba4bf9b9816ca8a15c8b85f440",
+			"branch": "master",
+			"path": "vendor/github.com/aristanetworks/goarista/monotime",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/ethereum/go-ethereum/vendor/github.com/btcsuite/btcd/btcec",
+			"repository": "https://github.com/ethereum/go-ethereum",
+			"vcs": "git",
+			"revision": "eaff89291ce998ba4bf9b9816ca8a15c8b85f440",
+			"branch": "master",
+			"path": "vendor/github.com/btcsuite/btcd/btcec",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/fatih/color",
 			"repository": "https://github.com/fatih/color",
 			"vcs": "git",

--- a/pbft/src/vendor/manifest
+++ b/pbft/src/vendor/manifest
@@ -446,12 +446,57 @@
 			"notests": true
 		},
 		{
-			"importpath": "golang.org/x/crypto/ssh/terminal",
+			"importpath": "golang.org/x/crypto/curve25519",
 			"repository": "https://go.googlesource.com/crypto",
 			"vcs": "git",
-			"revision": "7f39a6fea4fe9364fb61e1def6a268a51b4f3a06",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
 			"branch": "master",
-			"path": "/ssh/terminal",
+			"path": "curve25519",
+			"notests": true
+		},
+		{
+			"importpath": "golang.org/x/crypto/ed25519",
+			"repository": "https://go.googlesource.com/crypto",
+			"vcs": "git",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"branch": "master",
+			"path": "ed25519",
+			"notests": true
+		},
+		{
+			"importpath": "golang.org/x/crypto/internal/chacha20",
+			"repository": "https://go.googlesource.com/crypto",
+			"vcs": "git",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"branch": "master",
+			"path": "internal/chacha20",
+			"notests": true
+		},
+		{
+			"importpath": "golang.org/x/crypto/internal/subtle",
+			"repository": "https://go.googlesource.com/crypto",
+			"vcs": "git",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"branch": "master",
+			"path": "internal/subtle",
+			"notests": true
+		},
+		{
+			"importpath": "golang.org/x/crypto/poly1305",
+			"repository": "https://go.googlesource.com/crypto",
+			"vcs": "git",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"branch": "master",
+			"path": "poly1305",
+			"notests": true
+		},
+		{
+			"importpath": "golang.org/x/crypto/ssh",
+			"repository": "https://go.googlesource.com/crypto",
+			"vcs": "git",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"branch": "master",
+			"path": "/ssh",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
PBFT verifies if transaction has been sent from client by comparing public key generated from hash and ECDSA signature (in R || S || V format) with client public key generated in `bin/keys` folder, before adding it to block.